### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rtorr/sal.git"
+  },
   "keywords": [],
   "author": "rtorr <rtorruellas@gmail.com> (http://rtorr.com/)",
   "license": "MIT",


### PR DESCRIPTION
This allows people to easily find the [repository](https://github.com/rtorr/sal/) from the [npmjs page](https://www.npmjs.com/package/sal).
